### PR TITLE
chore(deps): bump decode-uri-component from 0.2.0 to 0.2.2

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2768,9 +2768,9 @@ decamelize@^1.1.0, decamelize@^1.1.1:
   integrity sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
 
 decode-uri-component@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
-  integrity sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.2.tgz#e69dbe25d37941171dd540e024c444cd5188e1e9"
+  integrity sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==
 
 deep-is@~0.1.3:
   version "0.1.3"


### PR DESCRIPTION
### Description

In this pull request, the version of the package `decode-uri-component` is being updated from `0.2.0` to `0.2.2` in the `yarn.lock` file.

Changes:
- Package `decode-uri-component`:
  - Upgrade version from `0.2.0` to `0.2.2`
  - Updated resolved URL
  - Updated integrity checksum